### PR TITLE
New MySQLStore constructor

### DIFF
--- a/mysqlstore.go
+++ b/mysqlstore.go
@@ -50,6 +50,10 @@ func NewMySQLStore(endpoint string, tableName string, path string, maxAge int, k
 		return nil, err
 	}
 
+	return NewMySQLStoreFromConnection(db, tableName, path, maxAge, keyPairs...)
+}
+
+func NewMySQLStoreFromConnection(db *sql.DB, tableName string, path string, maxAge int, keyPairs ...[]byte) (*MySQLStore, error) {
 	// Make sure table name is enclosed.
 	tableName = "`" + strings.Trim(tableName, "`") + "`"
 


### PR DESCRIPTION
Add a new constructor, `NewMySQLStoreFromConnection`, which accepts a `*sql.DB` and uses it instead of opening a new connection to the MySQL server, using the fact that database/sql already does connection pooling, etc.
