### PR TITLE
Fix syntax error in mysqlstore.go

### DIFF
--- a/mysqlstore.go
+++ b/mysqlstore.go
@@ -63,7 +63,7 @@ func NewMySQLStoreFromConnection(db *sql.DB, tableName string, path string, maxA
 		"created_on TIMESTAMP DEFAULT 0, " +
 		"modified_on TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP, " +
 		"expires_on TIMESTAMP DEFAULT 0, PRIMARY KEY(`id`)) ENGINE=InnoDB;"
-	if _, err = db.Exec(cTableQ); err != nil {
+	if _, err := db.Exec(cTableQ); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Previous change made a small error -- need to define the `err` variable.
