### PR TITLE
Make CREATE TABLE statement MySQL 5.7 compatible.

### DIFF
--- a/mysqlstore.go
+++ b/mysqlstore.go
@@ -60,9 +60,9 @@ func NewMySQLStoreFromConnection(db *sql.DB, tableName string, path string, maxA
 	cTableQ := "CREATE TABLE IF NOT EXISTS " +
 		tableName + " (id INT NOT NULL AUTO_INCREMENT, " +
 		"session_data LONGBLOB, " +
-		"created_on TIMESTAMP DEFAULT 0, " +
-		"modified_on TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP, " +
-		"expires_on TIMESTAMP DEFAULT 0, PRIMARY KEY(`id`)) ENGINE=InnoDB;"
+		"created_on TIMESTAMP DEFAULT NOW(), " +
+		"modified_on TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE CURRENT_TIMESTAMP, " +
+		"expires_on TIMESTAMP DEFAULT NOW(), PRIMARY KEY(`id`)) ENGINE=InnoDB;"
 	if _, err := db.Exec(cTableQ); err != nil {
 		switch err.(type) {
 		case *mysql.MySQLError:


### PR DESCRIPTION
The current create table statement won't work on MySQL 5.7, and causes initializing the session store to error.  The specific MySQL error is: `Error 1067: Invalid default value for 'modified_on'`.  I believe this change should be backwards-compatible to older MySQL versions.