### PR TITLE
Add automatic cleanup of expired tokens

### DIFF
--- a/cleanup.go
+++ b/cleanup.go
@@ -1,0 +1,59 @@
+package mysqlstore
+
+import (
+	"log"
+	"time"
+)
+
+var defaultInterval = time.Minute * 5
+
+// Cleanup runs a background goroutine every interval that deletes expired
+// sessions from the database.
+//
+// The design is based on https://github.com/yosssi/boltstore
+func (m *MySQLStore) Cleanup(interval time.Duration) (chan<- struct{}, <-chan struct{}) {
+	if interval <= 0 {
+		interval = defaultInterval
+	}
+
+	quit, done := make(chan struct{}), make(chan struct{})
+	go m.cleanup(interval, quit, done)
+	return quit, done
+}
+
+// StopCleanup stops the background cleanup from running.
+func (m *MySQLStore) StopCleanup(quit chan<- struct{}, done <-chan struct{}) {
+	quit <- struct{}{}
+	<-done
+}
+
+// cleanup deletes expired sessions at set intervals.
+func (m *MySQLStore) cleanup(interval time.Duration, quit <-chan struct{}, done chan<- struct{}) {
+	ticker := time.NewTicker(interval)
+
+	defer func() {
+		ticker.Stop()
+	}()
+
+	for {
+		select {
+		case <-quit:
+			// Handle the quit signal.
+			done <- struct{}{}
+			return
+		case <-ticker.C:
+			// Delete expired sessions on each tick.
+			err := m.deleteExpired()
+			if err != nil {
+				log.Printf("pgstore: unable to delete expired sessions: %v", err)
+			}
+		}
+	}
+}
+
+// deleteExpired deletes expired sessions from the database.
+func (m *MySQLStore) deleteExpired() error {
+	var deleteStmt = "DELETE FROM " + m.table + " WHERE expires_on < datetime('now')"
+	_, err := m.db.Exec(deleteStmt)
+	return err
+}

--- a/cleanup.go
+++ b/cleanup.go
@@ -45,7 +45,7 @@ func (m *MySQLStore) cleanup(interval time.Duration, quit <-chan struct{}, done 
 			// Delete expired sessions on each tick.
 			err := m.deleteExpired()
 			if err != nil {
-				log.Printf("pgstore: unable to delete expired sessions: %v", err)
+				log.Printf("mysqlstore: unable to delete expired sessions: %v", err)
 			}
 		}
 	}
@@ -53,7 +53,7 @@ func (m *MySQLStore) cleanup(interval time.Duration, quit <-chan struct{}, done 
 
 // deleteExpired deletes expired sessions from the database.
 func (m *MySQLStore) deleteExpired() error {
-	var deleteStmt = "DELETE FROM " + m.table + " WHERE expires_on < datetime('now')"
+	var deleteStmt = "DELETE FROM " + m.table + " WHERE expires_on < NOW()"
 	_, err := m.db.Exec(deleteStmt)
 	return err
 }


### PR DESCRIPTION
Users can optionally call `Cleanup()` to setup a goroutine which will prune expired tokens from the database