### PR TITLE
fixed time parsing issue on row scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+
+go:
+  - master
+  - 1.12
+  - 1.11.5
+
+services:
+  - mysql
+
+before_install:
+  - mysql -e 'CREATE DATABASE testdb;'
+
+script:
+  - go test -v ./... -dsn "travis@tcp(localhost:3306)/testdb"

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -2,5 +2,6 @@ Srinath G.S.
 Gregor Robinson.
 Brian Jones (from whom mysqlstore_test.go is derived).
 Andrejs Cainikovs.
+Ringo Hoffmann.
 The Gorilla Web Toolkit Authors.
 The Go Authors.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ mysqlstore
 
 [![Build Status](https://travis-ci.org/zekroTJA/mysqlstore.svg?branch=master)](https://travis-ci.org/zekroTJA/mysqlstore)
 
-Gorilla's Session Store Implementation for MySQL
+Gorilla's Session Store Implementation for MySQL.
+
+*Fixed version which is working with the current versions of Go.*
 
 Installation
 ===========
 
 Run `go get github.com/srinathgs/mysqlstore` from command line. Gets installed in `$GOPATH`.
-
-*Fixed version which is working with the current versions of Go.*
 
 Usage
 =====

--- a/README.md
+++ b/README.md
@@ -1,55 +1,63 @@
+> This project is a modified fork of [srinathgs/mysqlstore](https://github.com/srinathgs/mysqlstore).
+
 mysqlstore
 ==========
+
+[![Build Status](https://travis-ci.org/zekroTJA/mysqlstore.svg?branch=master)](https://travis-ci.org/zekroTJA/mysqlstore)
 
 Gorilla's Session Store Implementation for MySQL
 
 Installation
 ===========
 
-Run `go get github.com/srinathgs/mysqlstore` from command line. Gets installed in `$GOPATH`
+Run `go get github.com/srinathgs/mysqlstore` from command line. Gets installed in `$GOPATH`.
+
+*Fixed version which is working with the current versions of Go.*
 
 Usage
 =====
 
 `NewMysqlStore` takes the following paramaters
 
-    endpoint - A sql.Open style endpoint
-    tableName - table where sessions are to be saved. Required fields are created automatically if the table doesnot exist.
-    path - path for Set-Cookie header
-    maxAge 
-    codecs
+```
+endpoint - A sql.Open style endpoint
+tableName - table where sessions are to be saved. Required fields are created automatically if the table doesnot exist.
+path - path for Set-Cookie header
+maxAge 
+codecs
+```
 
 Internally, `mysqlstore` uses [this](https://github.com/go-sql-driver/mysql) MySQL driver.
 
-e.g.,
-      
+Example:
+```go
+package main
 
-      package main
-  
-      import (
-  	    "fmt"
-  	    "github.com/srinathgs/mysqlstore"
-  	    "net/http"
-      )
-  
-      var store *mysqlstore.MySQLStore
-  
-      func sessTest(w http.ResponseWriter, r *http.Request) {
-  	    session, err := store.Get(r, "foobar")
-  	    session.Values["bar"] = "baz"
-  	    session.Values["baz"] = "foo"
-  	    err = session.Save(r, w)
-  	    fmt.Printf("%#v\n", session)
-  	    fmt.Println(err)
-      }
+import (
+	"fmt"
+	"github.com/srinathgs/mysqlstore"
+	"net/http"
+)
 
-    func main() {
-        store, err := mysqlstore.NewMySQLStore("UN:PASS@tcp(<IP>:<PORT>)/<DB>?parseTime=true&loc=Local", <tablename>, "/", 3600, []byte("<SecretKey>"))
-        if err != nil {
-          panic(err)
-        }
-        defer store.Close()
+var store *mysqlstore.MySQLStore
 
-    	http.HandleFunc("/", sessTest)
-    	http.ListenAndServe(":8080", nil)
-    }
+func sessTest(w http.ResponseWriter, r *http.Request) {
+	session, err := store.Get(r, "foobar")
+	session.Values["bar"] = "baz"
+	session.Values["baz"] = "foo"
+	err = session.Save(r, w)
+	fmt.Printf("%#v\n", session)
+	fmt.Println(err)
+}
+
+func main() {
+	store, err := mysqlstore.NewMySQLStore("UN:PASS@tcp(<IP>:<PORT>)/<DB>?parseTime=true&loc=Local", <tablename>, "/", 3600, []byte("<SecretKey>"))
+	if err != nil {
+		panic(err)
+	}
+	defer store.Close()
+
+	http.HandleFunc("/", sessTest)
+	http.ListenAndServe(":8080", nil)
+}
+```

--- a/mysqlstore.go
+++ b/mysqlstore.go
@@ -8,16 +8,22 @@ package mysqlstore
 
 import (
 	"database/sql"
+	"database/sql/driver"
 	"encoding/gob"
 	"errors"
 	"fmt"
-	"github.com/go-sql-driver/mysql"
-	"github.com/gorilla/securecookie"
-	"github.com/gorilla/sessions"
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+)
+
+const (
+	timeFormat = "2006-01-02 15:04:05"
 )
 
 type MySQLStore struct {
@@ -269,10 +275,16 @@ func (m *MySQLStore) save(session *sessions.Session) error {
 func (m *MySQLStore) load(session *sessions.Session) error {
 	row := m.stmtSelect.QueryRow(session.ID)
 	sess := sessionRow{}
-	scanErr := row.Scan(&sess.id, &sess.data, &sess.createdOn, &sess.modifiedOn, &sess.expiresOn)
+	var timeCreated, timeModified, timeExpires driver.Value
+	scanErr := row.Scan(&sess.id, &sess.data, &timeCreated, &timeModified, &timeExpires)
 	if scanErr != nil {
 		return scanErr
 	}
+
+	sess.createdOn, _ = time.Parse(timeFormat, string(timeCreated.([]uint8)))
+	sess.modifiedOn, _ = time.Parse(timeFormat, string(timeModified.([]uint8)))
+	sess.expiresOn, _ = time.Parse(timeFormat, string(timeExpires.([]uint8)))
+
 	if sess.expiresOn.Sub(time.Now()) < 0 {
 		log.Printf("Session expired on %s, but it is %s now.", sess.expiresOn, time.Now())
 		return errors.New("Session expired")

--- a/mysqlstore_test.go
+++ b/mysqlstore_test.go
@@ -8,11 +8,16 @@ package mysqlstore
 
 import (
 	"encoding/gob"
+	"flag"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gorilla/sessions"
+)
+
+var (
+	flagDSN = flag.String("dsn", "testdb:testpw@tcp(localhost:3306)/testdb?parseTime=true&loc=Local", "MySQL conenction DSN")
 )
 
 type FlashMessage struct {
@@ -36,7 +41,7 @@ func TestMySQLStore(t *testing.T) {
 
 	// Round 1 ----------------------------------------------------------------
 
-	store, err := NewMySQLStore("testdb:testpw@tcp(localhost:3306)/testdb?parseTime=true&loc=Local",
+	store, err := NewMySQLStore(*flagDSN,
 		"sessionstore", "/", 3600, []byte("secret-key"))
 	if err != nil {
 		t.Fatalf("Error connecting to MySQL: %s", err.Error())
@@ -210,5 +215,6 @@ func TestMySQLStore(t *testing.T) {
 }
 
 func init() {
+	flag.Parse()
 	gob.Register(FlashMessage{})
 }

--- a/mysqlstore_test.go
+++ b/mysqlstore_test.go
@@ -8,10 +8,11 @@ package mysqlstore
 
 import (
 	"encoding/gob"
-	"github.com/gorilla/sessions"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/gorilla/sessions"
 )
 
 type FlashMessage struct {
@@ -35,10 +36,10 @@ func TestMySQLStore(t *testing.T) {
 
 	// Round 1 ----------------------------------------------------------------
 
-	store, err := NewMySQLStore("testuser:testpw@tcp(localhost:3306)/testdb?parseTime=true&loc=Local",
+	store, err := NewMySQLStore("testdb:testpw@tcp(localhost:3306)/testdb?parseTime=true&loc=Local",
 		"sessionstore", "/", 3600, []byte("secret-key"))
 	if err != nil {
-		t.Fatalf("Error connecting to MySQL: ", err)
+		t.Fatalf("Error connecting to MySQL: %s", err.Error())
 	}
 	defer store.Close()
 
@@ -65,7 +66,7 @@ func TestMySQLStore(t *testing.T) {
 	hdr = rsp.Header()
 	cookies, ok = hdr["Set-Cookie"]
 	if !ok || len(cookies) != 1 {
-		t.Fatalf("No cookies. Header:", hdr)
+		t.Fatalf("No cookies. Header: %v", hdr)
 	}
 
 	// Round 2 ----------------------------------------------------------------
@@ -130,7 +131,7 @@ func TestMySQLStore(t *testing.T) {
 	hdr = rsp.Header()
 	cookies, ok = hdr["Set-Cookie"]
 	if !ok || len(cookies) != 1 {
-		t.Fatalf("No cookies. Header:", hdr)
+		t.Fatalf("No cookies. Header: %v", hdr)
 	}
 
 	// Round 4 ----------------------------------------------------------------
@@ -183,7 +184,7 @@ func TestMySQLStore(t *testing.T) {
 	hdr = rsp.Header()
 	cookies, ok = hdr["Set-Cookie"]
 	if !ok || len(cookies) != 1 {
-		t.Fatalf("No cookies. Header:", hdr)
+		t.Fatalf("No cookies. Header: %v", hdr)
 	}
 
 	// Round 6 ----------------------------------------------------------------


### PR DESCRIPTION
Using this library on the current version of Go does not work because the row scan on loading database data fails with following error:

Code line:
```go
scanErr := row.Scan(&sess.id, &sess.data, &sess.createdOn, &sess.modifiedOn, &sess.expiresOn)
```

Error: 
```
sql: Scan error on column index 2, name "created_on": unsupported Scan, storing driver.Value type []uint8 into type *time.Time
```

I have fixed this error by scanning the timestamps from row as array of `uint8` and parsing it later to a time object:

```go
var timeCreated, timeModified, timeExpires driver.Value
scanErr := row.Scan(&sess.id, &sess.data, &timeCreated, &timeModified, &timeExpires)
if scanErr != nil {
	return scanErr
}

sess.createdOn, _ = time.Parse(timeFormat, string(timeCreated.([]uint8)))
sess.modifiedOn, _ = time.Parse(timeFormat, string(timeModified.([]uint8)))
sess.expiresOn, _ = time.Parse(timeFormat, string(timeExpires.([]uint8)))
```

Here are the travis-ci test logs of your repositories state (`original` branch) and my changes (`master` branch):
- original: https://travis-ci.org/zekroTJA/mysqlstore/builds/502682653
- changed: https://travis-ci.org/zekroTJA/mysqlstore/builds/502683120

I would really appreciate merging this PR or fixing the issue yourself because this repository is recommendet from the [gorilla/sessions](https://github.com/gorilla/sessions) repository and does not work with current versions of Go and/or MySQL.